### PR TITLE
Added root check for chown

### DIFF
--- a/acme.sh
+++ b/acme.sh
@@ -1394,10 +1394,12 @@ issue() {
 
         mkdir -p "$wellknown_path"
         printf "%s" "$keyauthorization" > "$wellknown_path/$token"
-        if [ ! "$usingApache" ] ; then
+        if [ ! "$usingApache" ] && [ "$UID" = "0" ] ; then
           webroot_owner=$(_stat $_currentRoot)
           _debug "Changing owner/group of .well-known to $webroot_owner"
           chown -R $webroot_owner "$_currentRoot/.well-known"
+        elif [ ! "$UID" = "0" ]; then
+          _debug "Not changing owner/group of .well-known as am not running as root."
         fi
         
       fi


### PR DESCRIPTION
Added a check to ensure that the script is running as root before attempting to chown the well-known directory. It is not critical that the ownership be changed, and the script functions fine in common scenarios. This just removes the ugly error message:
```
chown: changing ownership of '<path>/.well-known/acme-challenge/<token>': Operation not permitted
```
(This may be undesirable in a selinux scenario where the user the script is running as has such ability, but that is an edge case). An alternative would be to redirect stderr on that one command, or check the exit code and print a message explaining that it's probably fine that it couldn't.